### PR TITLE
feat: add launch details page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import { HashRouter as Router, Switch, Route } from "react-router-dom";
 import Home from "./views/pages/Home";
 import LaunchesList from "./views/pages/launches-list/LaunchesList"
+import LaunchDetails from "./views/pages/launch-details/LaunchDetails"
 import NotFound404 from "./views/pages/not-found-404/NotFound404"
 
 function App() {
@@ -18,6 +19,9 @@ function App() {
         </Route>
         <Route exact path="/upcoming-launches">
           <LaunchesList type="upcoming" />
+        </Route>
+        <Route exact path="/launch/:id">
+          <LaunchDetails />
         </Route>
         <Route path="*">
           <NotFound404 />

--- a/src/utils/ConvertTimeStampToLocal.js
+++ b/src/utils/ConvertTimeStampToLocal.js
@@ -1,5 +1,9 @@
 const ConvertTimeStampToLocal = (timeStamp, locales, options) => {
-  return new Date(timeStamp).toLocaleTimeString(locales, options)
+  if (typeof timeStamp !== "number" || Number.isNaN(timeStamp)) {
+    return "—"
+  }
+  const defaultOptions = { dateStyle: "medium", timeStyle: "short" }
+  return new Date(timeStamp * 1000).toLocaleString(locales, options || defaultOptions)
 }
 
 export default ConvertTimeStampToLocal

--- a/src/utils/transformLaunchData.js
+++ b/src/utils/transformLaunchData.js
@@ -1,4 +1,48 @@
 /**
+ * Transforms a single Space Devs API launch to match the old SpaceX API schema
+ * This ensures backward compatibility with existing components
+ */
+export const transformSingleLaunch = (launch) => {
+  // Extract flight number from launch id or use null when unavailable
+  const flightNumber = launch.flight_number || null;
+  
+  // Convert ISO date string to Unix timestamp
+  const launchDateUnix = launch.net ? Math.floor(new Date(launch.net).getTime() / 1000) : null;
+  
+  // Determine launch success based on status
+  const launchSuccess = launch.status?.id === 3 ? true : 
+                       launch.status?.id === 4 || launch.status?.id === 7 ? false : 
+                       null;
+  
+  return {
+    id: launch.id || '',
+    flight_number: flightNumber,
+    mission_name: launch.name || '',
+    launch_date_unix: launchDateUnix,
+    launch_date_utc: launch.net || '',
+    launch_success: launchSuccess,
+    status_name: launch.status?.name || '',
+    rocket: {
+      rocket_id: launch.rocket?.configuration?.id || '',
+      rocket_name: launch.rocket?.configuration?.name || 'Unknown',
+      rocket_type: launch.rocket?.configuration?.variant || launch.rocket?.configuration?.family || 'Unknown'
+    },
+    launch_site: {
+      site_id: launch.pad?.id || '',
+      site_name: launch.pad?.name || 'Unknown',
+      site_name_long: launch.pad?.location?.name || ''
+    },
+    details: launch.mission?.description || '',
+    links: {
+      mission_patch: null,
+      mission_patch_small: null,
+      article_link: launch.mission?.info_urls?.[0] || null,
+      video_link: launch.mission?.vid_urls?.[0] || null
+    }
+  };
+};
+
+/**
  * Transforms Space Devs API data to match the old SpaceX API schema
  * This ensures backward compatibility with existing components
  */
@@ -7,41 +51,8 @@ export const transformLaunchData = (spaceDevsData) => {
     return [];
   }
 
-  return spaceDevsData.results.map((launch, index) => {
-    // Extract flight number from launch id or use index
-    const flightNumber = launch.flight_number || index + 1;
-    
-    // Convert ISO date string to Unix timestamp
-    const launchDateUnix = launch.net ? Math.floor(new Date(launch.net).getTime() / 1000) : null;
-    
-    // Determine launch success based on status
-    const launchSuccess = launch.status?.id === 3 ? true : 
-                         launch.status?.id === 4 || launch.status?.id === 7 ? false : 
-                         null;
-    
-    return {
-      flight_number: flightNumber,
-      mission_name: launch.name || '',
-      launch_date_unix: launchDateUnix,
-      launch_date_utc: launch.net || '',
-      launch_success: launchSuccess,
-      rocket: {
-        rocket_id: launch.rocket?.configuration?.id || '',
-        rocket_name: launch.rocket?.configuration?.name || 'Unknown',
-        rocket_type: launch.rocket?.configuration?.variant || launch.rocket?.configuration?.family || 'Unknown'
-      },
-      launch_site: {
-        site_id: launch.pad?.id || '',
-        site_name: launch.pad?.name || 'Unknown',
-        site_name_long: launch.pad?.location?.name || ''
-      },
-      details: launch.mission?.description || '',
-      links: {
-        mission_patch: null,
-        mission_patch_small: null,
-        article_link: launch.mission?.info_urls?.[0] || null,
-        video_link: launch.mission?.vid_urls?.[0] || null
-      }
-    };
-  });
+  return spaceDevsData.results.map((launch, index) => ({
+    ...transformSingleLaunch(launch),
+    flight_number: launch.flight_number || index + 1,
+  }));
 };

--- a/src/views/components/check/Check.js
+++ b/src/views/components/check/Check.js
@@ -9,7 +9,7 @@ function Check({check = false}) {
   }
 
   if (check === null) {
-    return (<div className="unstate"><span className="tooltiptext">Un State</span><FontAwesomeIcon icon={faMinus} /></div>)
+    return (<div className="unstate"><span className="tooltiptext">Unknown</span><FontAwesomeIcon icon={faMinus} /></div>)
   }
 
   return (

--- a/src/views/components/menu/Menu.js
+++ b/src/views/components/menu/Menu.js
@@ -4,13 +4,13 @@ import "./Menu.scss"
 function Menu({vertical}) {
   return (
     <ul className={`menu ${vertical ? "menu-vertical" : ""}`}>
-      <Link to="all-launches">
+      <Link to="/all-launches">
         <li>All Launches</li>
       </Link>
-      <Link to="past-launches">
+      <Link to="/past-launches">
         <li>Past Launches</li>
       </Link>
-      <Link to="upcoming-launches">
+      <Link to="/upcoming-launches">
         <li>Upcoming Launches</li>
       </Link>
     </ul>

--- a/src/views/components/table/Table.js
+++ b/src/views/components/table/Table.js
@@ -1,8 +1,24 @@
 import "./Table.scss"
+import { useHistory } from "react-router-dom"
 import { ConvertTimeStampToLocal } from "../../../utils/Utils"
 import Check from "../check/Check"
 
 function Table(props) {
+  const history = useHistory()
+
+  const goToLaunch = (launch) => {
+    if (launch.id) {
+      history.push(`/launch/${launch.id}`)
+    }
+  }
+
+  const handleRowKeyDown = (event, launch) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault()
+      goToLaunch(launch)
+    }
+  }
+
   return (
     <div className="wrap-table">
       <div className="table">
@@ -24,7 +40,14 @@ function Table(props) {
           <table>
             <tbody>
               {props.data.map((launch, index) => (
-                <tr key={index}>
+                <tr
+                  key={launch.id || index}
+                  tabIndex={0}
+                  role="link"
+                  aria-label={`View details for ${launch.mission_name}`}
+                  onClick={() => goToLaunch(launch)}
+                  onKeyDown={(event) => handleRowKeyDown(event, launch)}
+                >
                   <td className="column1">{launch.flight_number}</td>
                   <td className="column2">{ConvertTimeStampToLocal(launch.launch_date_unix)}</td>
                   <td className="column3">{launch.rocket.rocket_name}</td>

--- a/src/views/components/table/Table.scss
+++ b/src/views/components/table/Table.scss
@@ -27,6 +27,13 @@
         padding-top: 16px;
         padding-bottom: 16px;
       }
+      tr {
+        cursor: pointer;
+        &:focus {
+          outline: 2px solid var(--accent-primary);
+          outline-offset: -2px;
+        }
+      }
       tr:nth-child(even) {
         background-color: var(--surface-alt);
         transition: background-color 0.3s ease;

--- a/src/views/pages/launch-details/LaunchDetails.js
+++ b/src/views/pages/launch-details/LaunchDetails.js
@@ -1,0 +1,139 @@
+import { useEffect, useState } from "react"
+import { useHistory, useParams, Link } from "react-router-dom"
+import "./LaunchDetails.scss"
+import Axios from "../../../Axios"
+import { ConvertTimeStampToLocal } from "../../../utils/Utils"
+import { transformSingleLaunch } from "../../../utils/transformLaunchData"
+import Header from "../../components/header/Header"
+import Menu from "../../components/menu/Menu"
+import Loading from "../../components/loading/Loading"
+
+function LaunchDetails() {
+  const { id } = useParams()
+  const history = useHistory()
+  const [launch, setLaunch] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    let mounted = true
+
+    const fetchLaunch = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const response = await Axios.get(`launch/${id}/`)
+        if (mounted) {
+          setLaunch(transformSingleLaunch(response.data))
+        }
+      } catch (err) {
+        console.error("Error fetching launch details:", err)
+        if (mounted) {
+          setError(err.response?.status === 404 ? "not-found" : "generic")
+        }
+      } finally {
+        if (mounted) {
+          setLoading(false)
+        }
+      }
+    }
+
+    fetchLaunch()
+
+    return () => {
+      mounted = false
+    }
+  }, [id])
+
+  if (loading) {
+    return <Loading />
+  }
+
+  return (
+    <article className="launch-details">
+      {error ? (
+        <section className="launch-details-card">
+          <div className="launch-details-error">
+            {error === "not-found" ? (
+              <>
+                <h1>Launch not found</h1>
+                <p>We couldn't load the details for this launch. It may have been removed or the link may be invalid.</p>
+              </>
+            ) : (
+              <>
+                <h1>Something went wrong</h1>
+                <p>We couldn't load the details for this launch. Please try again.</p>
+              </>
+            )}
+            <Link to="/all-launches" className="launch-details-link">Back to All Launches</Link>
+          </div>
+        </section>
+      ) : (
+        <>
+          <section className="launch-details-card">
+            <div className="launch-details-header">
+              <button
+                type="button"
+                className="launch-details-back"
+                onClick={() => (history.length > 1 ? history.goBack() : history.push("/all-launches"))}
+              >
+                &#8592; Back
+              </button>
+              <h1>{launch.mission_name}</h1>
+              <span className="launch-details-status">{launch.status_name || (launch.launch_success === true ? "Successful" : launch.launch_success === false ? "Failed" : "Unknown")}</span>
+            </div>
+            <div className="launch-details-body">
+              <div className="launch-details-detail">
+                <span className="label">Flight</span>
+                <span className="value">{launch.flight_number || "—"}</span>
+              </div>
+              <div className="launch-details-detail">
+                <span className="label">Launch Date</span>
+                <span className="value">{ConvertTimeStampToLocal(launch.launch_date_unix)}</span>
+              </div>
+              <div className="launch-details-detail">
+                <span className="label">Rocket Name</span>
+                <span className="value">{launch.rocket.rocket_name}</span>
+              </div>
+              <div className="launch-details-detail">
+                <span className="label">Rocket Type</span>
+                <span className="value">{launch.rocket.rocket_type}</span>
+              </div>
+              <div className="launch-details-detail">
+                <span className="label">Site Name</span>
+                <span className="value">{launch.launch_site.site_name_long || launch.launch_site.site_name}</span>
+              </div>
+              <div className="launch-details-detail">
+                <span className="label">Launch Success</span>
+                <span className="value">{launch.launch_success === true ? "Yes" : launch.launch_success === false ? "No" : "Unknown"}</span>
+              </div>
+            </div>
+            <div className="launch-details-description">
+              <h2>Details</h2>
+              <p>{launch.details || "No details available for this launch."}</p>
+            </div>
+            {(launch.links.article_link || launch.links.video_link) && (
+              <div className="launch-details-links">
+                <h2>Links</h2>
+                {launch.links.article_link && (
+                  <a href={launch.links.article_link} target="_blank" rel="noopener noreferrer" className="launch-details-link">Read Article</a>
+                )}
+                {launch.links.video_link && (
+                  <a href={launch.links.video_link} target="_blank" rel="noopener noreferrer" className="launch-details-link">Watch Video</a>
+                )}
+              </div>
+            )}
+          </section>
+          <div className="boxes">
+            <aside>
+              <Header />
+              <Menu vertical />
+            </aside>
+          </div>
+        </>
+      )}
+    </article>
+  )
+}
+
+export default LaunchDetails

--- a/src/views/pages/launch-details/LaunchDetails.scss
+++ b/src/views/pages/launch-details/LaunchDetails.scss
@@ -1,0 +1,168 @@
+.launch-details {
+  display: flex;
+  align-items: flex-start;
+  justify-content: stretch;
+  padding: 36px;
+  &::after {
+    position: absolute;
+    z-index: -2;
+    top: 10%;
+    left: 0;
+    width: 200%;
+    height: 200%;
+    content: "";
+    background-color: var(--accent-secondary);
+    transform: rotate(-20deg);
+    transition: background-color 0.3s ease;
+  }
+  &::before {
+    content: "";
+    position: absolute;
+    width: 200%;
+    height: 200%;
+    top: 70%;
+    left: -50%;
+    z-index: -1;
+    background-color: var(--accent-primary);
+    transform: rotate(5deg);
+    transition: background-color 0.3s ease;
+  }
+  .boxes {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-start;
+    min-width: 210px;
+    min-height: 100px;
+    padding: 16px;
+    margin-left: 16px;
+    margin-bottom: 16px;
+    background-color: var(--surface);
+    border-radius: 10px;
+    box-sizing: border-box;
+    box-shadow: 0 0px 40px 0px var(--shadow-color);
+    transition: background-color 0.3s ease, box-shadow 0.3s ease;
+  }
+  .launch-details-card {
+    flex-grow: 1;
+    min-width: 320px;
+    background-color: var(--surface);
+    border-radius: 10px;
+    box-shadow: 0 0px 40px 0px var(--shadow-color);
+    transition: background-color 0.3s ease, box-shadow 0.3s ease;
+    overflow: hidden;
+  }
+  .launch-details-header {
+    padding: 24px 32px;
+    background-color: var(--accent-header);
+    color: var(--text-on-accent);
+    .launch-details-back {
+      display: inline-block;
+      margin-bottom: 16px;
+      padding: 8px 16px;
+      font-size: 14px;
+      font-family: inherit;
+      color: var(--text-on-accent);
+      background-color: transparent;
+      border: 1px solid var(--text-on-accent);
+      border-radius: 50px;
+      cursor: pointer;
+      transition: background-color 0.3s ease, color 0.3s ease;
+      &:hover {
+        background-color: var(--text-on-accent);
+        color: var(--accent-header);
+      }
+    }
+    h1 {
+      font-size: 28px;
+      font-weight: 700;
+      line-height: 1.3;
+    }
+    .launch-details-status {
+      display: inline-block;
+      margin-top: 8px;
+      font-size: 15px;
+      opacity: 0.9;
+    }
+  }
+  .launch-details-body {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+    padding: 24px 32px;
+    .launch-details-detail {
+      display: flex;
+      flex-direction: column;
+      .label {
+        font-size: 13px;
+        color: var(--text-secondary);
+        margin-bottom: 6px;
+      }
+      .value {
+        font-size: 16px;
+        color: var(--text-primary);
+        line-height: 1.4;
+      }
+    }
+  }
+  .launch-details-description,
+  .launch-details-links {
+    padding: 16px 32px 24px;
+    h2 {
+      font-size: 18px;
+      font-weight: 700;
+      margin-bottom: 8px;
+      color: var(--text-primary);
+    }
+    p {
+      font-size: 15px;
+      line-height: 1.6;
+      color: var(--text-secondary);
+    }
+  }
+  .launch-details-links {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 16px;
+    h2 {
+      flex-basis: 100%;
+    }
+  }
+  .launch-details-link {
+    display: inline-block;
+    padding: 8px 20px;
+    font-size: 14px;
+    text-decoration: none;
+    color: var(--text-on-accent);
+    background-color: var(--accent-primary);
+    border-radius: 50px;
+    transition: background-color 0.3s ease;
+    &:hover {
+      background-color: var(--accent-header);
+    }
+  }
+  .launch-details-error {
+    padding: 64px 32px;
+    text-align: center;
+    h1 {
+      font-size: 32px;
+      font-weight: 700;
+      margin-bottom: 16px;
+      color: var(--text-primary);
+    }
+    p {
+      font-size: 15px;
+      line-height: 1.6;
+      color: var(--text-secondary);
+      margin-bottom: 24px;
+    }
+  }
+  @media screen and (max-width: 650px) {
+    flex-direction: column-reverse;
+    .boxes {
+      display: flex;
+      flex-direction: row;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Implements issue #16 — **Launch Details Page**.

Creates a details page for each launch that opens when clicking any row in the launches table, navigates to a dedicated route, and shows the launch details fetched from the API.

## Changes
- **New route** `/launch/:id` in `src/App.js` → `LaunchDetails` page
- **New page** `src/views/pages/launch-details/LaunchDetails.js` (+ `.scss`):
  - Fetches single launch from the Space Devs API (`launch/:id/`)
  - Shows mission name, flight number, launch date, rocket name/type, site name, success state, details, and article/video links
  - Loading spinner, 404 vs. generic error states, and safe back navigation (handles deep links)
- **Clickable table rows** in `Table.js`:
  - `onClick` navigates to the launch details route
  - Keyboard accessible: `tabIndex`, `role="link"`, `aria-label`, Enter/Space handlers
  - Visible `:focus` outline in both themes
- **Bug fix** `ConvertTimeStampToLocal.js`: corrects Unix-seconds → ms conversion so launch dates render properly (date + time), with a defensive guard for invalid input
- **Refactor** `transformLaunchData.js`: extracts `transformSingleLaunch`, adds `id` and `status_name` fields (superset — no breaking changes to existing consumers)
- **Menu fix** `Menu.js`: absolute links prevent route collisions under `/launch/:id`
- **Tiny copy fix** `Check.js`: "Un State" → "Unknown"

## Files changed
- `src/App.js`
- `src/utils/ConvertTimeStampToLocal.js`
- `src/utils/transformLaunchData.js`
- `src/views/components/check/Check.js`
- `src/views/components/menu/Menu.js`
- `src/views/components/table/Table.js`
- `src/views/components/table/Table.scss`
- `src/views/pages/launch-details/LaunchDetails.js` (new)
- `src/views/pages/launch-details/LaunchDetails.scss` (new)

## Verification
- `yarn build` compiles successfully
- Reviewed and **approved** by the reviewer agent (all major/minor findings addressed)